### PR TITLE
Updated for latest Babel version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "duo-babel",
   "description": "Turn ES6 code into readable vanilla ES5 with source maps using Duo",
-  "version": "4.0.0",
+  "version": "4.4.3",
   "keywords": [
     "es6",
     "ecma",
@@ -14,7 +14,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "babel-core": "^4.0.0"
+    "babel-core": "4.4.3"
   },
   "devDependencies": {
     "duo": "~0.8.5",


### PR DESCRIPTION
If the goal is to match the version of this repo to the actual babel then it should just have a fixed version
