### PR TITLE
Updating remote file check

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function plugin(opts){
 
   return function babel(file){
     if ('js' !== file.type) return;
-    if (onlyLocals && file.id.indexOf('@') > -1) return; // ignore any remotes
+    if (onlyLocals && file.remote()) return; // ignore any remotes
     var es5 = compile(file.src, opts);
     file.src = es5.code;
   }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "Henrik Kjelsberg <henrik.kjelsberg@bdo.no>",
   "repository": "babel/duo-babel",
   "scripts": {
-    "test": "mocha --harmony-generators"
+    "test": "mocha --harmony"
   },
   "dependencies": {
     "babel-core": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -11,13 +11,13 @@
   "author": "Henrik Kjelsberg <henrik.kjelsberg@bdo.no>",
   "repository": "babel/duo-babel",
   "scripts": {
-    "test": "mocha --harmony"
+    "test": "mocha --harmony-generators"
   },
   "dependencies": {
     "babel-core": "^5.0.0"
   },
   "devDependencies": {
-    "duo": "~0.8.5",
+    "duo": "^0.10.0",
     "mocha": "~1.21.5"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -17,7 +17,7 @@ describe('duo-babel', function() {
   it('should compile .js', function(done) {
     build('simple').run(function(err, src) {
       if (err) return done(err);
-      assert(src.indexOf('var TRANSFORMED') !== -1);
+      assert(src.code.indexOf('var TRANSFORMED') !== -1);
       done();
     });
   });
@@ -26,7 +26,7 @@ describe('duo-babel', function() {
     build('remote', { onlyLocals: true }).run(function (err, src) {
       if (err) return done(err);
       // console.log(src);
-      var ret = evaluate(src);
+      var ret = evaluate(src.code);
       // console.log(ret);
       done();
     });


### PR DESCRIPTION
Since `v0.9.0` of duo, there is a helpful API plugins can use to check for remote/local files, so I've made that change here.

This also fixes the tests, (just needed to add the `--harmony-generators` flag) as well as updates duo to the latest version for the purposes of running tests.
