### PR TITLE
Improving options support (+ source-maps)

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
  */
 
 var compile = require('babel-core').transform;
+var extend = require('extend');
 
 /**
  * Expose `plugin`.
@@ -14,20 +15,41 @@ module.exports = plugin;
 /**
  * babel plugin
  *
- * @param {Object} opts
+ * @param {Object} o
  * @return {Function}
  */
 
-function plugin(opts){
-  opts = opts || {};
+function plugin(o){
+  var opts = extend({}, plugin.defaults, o);
 
-  var onlyLocals = !!opts.onlyLocals;
+  // extract the onlyLocals option
+  var onlyLocals = opts.onlyLocals;
   delete opts.onlyLocals;
 
   return function babel(file){
     if ('js' !== file.type) return;
     if (onlyLocals && file.remote()) return; // ignore any remotes
-    var es5 = compile(file.src, opts);
+
+    // add more options that can only be found during runtime
+    var options = extend({}, opts, {
+      filename: file.path,
+      filenameRelative: file.id,
+      sourceRoot: file.root
+    });
+
+    var es5 = compile(file.src, options);
     file.src = es5.code;
   }
 }
+
+/**
+ * default configuration options
+ */
+
+plugin.defaults = {
+  // skips downloaded remotes (for compatibility reasons)
+  onlyLocals: false,
+
+  // so duo can include them in it's own source-map
+  sourceMap: 'inline'
+};

--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@
  */
 
 var compile = require('babel-core').transform;
-var extend = require('extend');
 
 /**
  * Expose `plugin`.
@@ -20,36 +19,22 @@ module.exports = plugin;
  */
 
 function plugin(o){
-  var opts = extend({}, plugin.defaults, o);
+  if (!o) o = {};
 
   // extract the onlyLocals option
-  var onlyLocals = opts.onlyLocals;
-  delete opts.onlyLocals;
+  var onlyLocals = o.onlyLocals || false;
 
-  return function babel(file){
+  return function babel(file, entry) {
     if ('js' !== file.type) return;
     if (onlyLocals && file.remote()) return; // ignore any remotes
 
-    // add more options that can only be found during runtime
-    var options = extend({}, opts, {
+    var es5 = compile(file.src, {
       filename: file.path,
       filenameRelative: file.id,
-      sourceRoot: file.root
+      sourceRoot: file.root,
+      sourceMap: !!file.duo.sourceMap() ? 'inline' : false
     });
 
-    var es5 = compile(file.src, options);
     file.src = es5.code;
   }
 }
-
-/**
- * default configuration options
- */
-
-plugin.defaults = {
-  // skips downloaded remotes (for compatibility reasons)
-  onlyLocals: false,
-
-  // so duo can include them in it's own source-map
-  sourceMap: 'inline'
-};

--- a/package.json
+++ b/package.json
@@ -14,12 +14,11 @@
     "test": "mocha --harmony"
   },
   "dependencies": {
-    "babel-core": "^5.0.0",
-    "extend": "^2.0.0"
+    "babel-core": "^5.0.0"
   },
   "devDependencies": {
     "convert-source-map": "^1.0.0",
-    "duo": "^0.10.0",
+    "duo": "^0.11.1",
     "mocha": "~1.21.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,9 +14,11 @@
     "test": "mocha --harmony"
   },
   "dependencies": {
-    "babel-core": "^5.0.0"
+    "babel-core": "^5.0.0",
+    "extend": "^2.0.0"
   },
   "devDependencies": {
+    "convert-source-map": "^1.0.0",
     "duo": "^0.10.0",
     "mocha": "~1.21.5"
   }

--- a/test/index.js
+++ b/test/index.js
@@ -33,8 +33,16 @@ describe('duo-babel', function() {
     });
   });
 
-  it('should include an inline source-map by default', function(done) {
-    build('simple').run(function(err, src) {
+  it('should include an inline source-map when duo is including inline source-maps', function(done) {
+    build('simple').sourceMap('inline').run(function(err, src) {
+      if (err) return done(err);
+      assert(convert.commentRegex.test(src.code));
+      done();
+    })
+  });
+
+  it('should include an inline source-map when duo is including external source-maps', function(done) {
+    build('simple').sourceMap(true).run(function(err, src) {
       if (err) return done(err);
       assert(convert.commentRegex.test(src.code));
       done();
@@ -42,7 +50,7 @@ describe('duo-babel', function() {
   });
 
   it('should not include an inline source-map', function(done) {
-    build('simple', { sourceMap: false }).run(function(err, src) {
+    build('simple').run(function(err, src) {
       if (err) return done(err);
       assert(!convert.commentRegex.test(src.code));
       done();

--- a/test/index.js
+++ b/test/index.js
@@ -4,9 +4,10 @@
  */
 
 var assert = require('assert');
+var convert = require('convert-source-map');
 var Duo = require('duo');
 var path = require('path');
-var to5 = require('..');
+var babel = require('..');
 var vm = require('vm');
 
 /**
@@ -31,6 +32,22 @@ describe('duo-babel', function() {
       done();
     });
   });
+
+  it('should include an inline source-map by default', function(done) {
+    build('simple').run(function(err, src) {
+      if (err) return done(err);
+      assert(convert.commentRegex.test(src));
+      done();
+    })
+  });
+
+  it('should not include an inline source-map', function(done) {
+    build('simple', { sourceMap: false }).run(function(err, src) {
+      if (err) return done(err);
+      assert(!convert.commentRegex.test(src));
+      done();
+    })
+  });
 });
 
 /**
@@ -45,7 +62,7 @@ function build(fixture, options) {
   return Duo(__dirname)
     .cache(false)
     .entry('fixtures/' + fixture + '.js')
-    .use(to5(options));
+    .use(babel(options));
 }
 
 /**

--- a/test/index.js
+++ b/test/index.js
@@ -36,7 +36,7 @@ describe('duo-babel', function() {
   it('should include an inline source-map by default', function(done) {
     build('simple').run(function(err, src) {
       if (err) return done(err);
-      assert(convert.commentRegex.test(src));
+      assert(convert.commentRegex.test(src.code));
       done();
     })
   });
@@ -44,7 +44,7 @@ describe('duo-babel', function() {
   it('should not include an inline source-map', function(done) {
     build('simple', { sourceMap: false }).run(function(err, src) {
       if (err) return done(err);
-      assert(!convert.commentRegex.test(src));
+      assert(!convert.commentRegex.test(src.code));
       done();
     })
   });


### PR DESCRIPTION
- using `extend` to cleanly create intermediary options objects
- exposing defaults publicly to allow customization
- adding `sourceMap: 'inline'` option (allows duo to merge into it's final source-map)
- adding runtime options (`filename`, `sourceRoot`, `filenameRelative`) before compile
