### PR TITLE
Adding "only" and "ignore" support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,7 +2,7 @@
 
 # duo-babel
 
-[duo](http://duojs.org)-plugin for [babel](/babel/babel).
+> [duo](http://duojs.org)-plugin for [babel](/babel/babel).
 
 
 ## Installation
@@ -39,8 +39,31 @@ Duo(__dirname)
 
 Initialize a duo plugin. Available `options`:
 
- * `onlyLocals` will skip compiling remote dependencies when true
+ * `only` a list of glob patterns to only transpile
+ * `ignore` a list of glob patterns to not transpile (the opposite of `only`)
  * anything else is passed directly to [babel](https://babeljs.io/docs/usage/options/)
+
+
+### Patterns for only / ignore
+
+You can add an array as either `only` _or_ `ignore` (not both) to selectively
+enable babel's transpilation.
+
+The list you provide are simple glob patterns, with 2 special cases:
+
+ - "locals" refers to any local modules
+ - "remotes" refers to any downloaded modules
+
+Aside from the above 2, your patterns should match the directory structure that
+duo uses. (and that you can see on disk)
+
+ - `components/component-*/**.js` will match anything in the
+   [component](https://github.com/component) organization.
+ - `components/lodash-lodash@*/**.js` will match any version of lodash
+ - `lib/**.js` will match any JS file in the local lib dir
+
+
+### Source Maps
 
 ES6 source-maps are turned on automatically when duo has enabled source-maps,
 this feature can be disabled by explicitly setting the `sourceMaps` option.

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@
 
 var compile = require('babel-core').transform;
 var extend = require('extend');
+var path = require('path');
 
 /**
  * Expose `plugin`.
@@ -13,7 +14,14 @@ var extend = require('extend');
 module.exports = plugin;
 
 /**
- * babel plugin
+ * Babel plugin for Duo.
+ *
+ * Available options:
+ *  - onlyLocals {Boolean}
+ *  - only {Array:String}    List of modules to allow
+ *  - ignore {Array:String}  List of modules to exclude
+ *
+ * All other options will be proxied to babel directly.
  *
  * @param {Object} o
  * @return {Function}
@@ -22,19 +30,27 @@ module.exports = plugin;
 function plugin(o) {
   if (!o) o = {};
 
-  // extract the onlyLocals option
-  var onlyLocals = o.onlyLocals || false;
-  delete o.onlyLocals;
+  var should = shouldTranspile(o.only, o.ignore);
+
+  var only = o.only;
+  delete o.only;
+
+  var ignore = o.ignore;
+  delete o.ignore;
 
   return function babel(file, entry) {
-    if (file.type !== 'js') return;          // ignore non-js
-    if (onlyLocals && file.remote()) return; // ignore any remotes
+    if (file.type !== 'js') return;  // ignore non-js
+    if (!should(file)) return;       // user-specified ignores
+
+    var root = file.duo.root();
 
     var options = extend(true, {
       filename: file.path,
       filenameRelative: file.id,
       sourceMap: !!file.duo.sourceMap() ? 'inline' : false,
-      sourceRoot: '/'
+      sourceRoot: '/',
+      only: prepend(only, root),
+      ignore: prepend(ignore, root)
     }, o);
 
     try {
@@ -43,5 +59,88 @@ function plugin(o) {
     } catch (err) {
       throw new Error(err.message);
     }
+  };
+}
+
+/**
+ * Return a helper function that tests if a file/module should be transpiled.
+ *
+ * This makes the following modifications to the input arrays:
+ *  - extracts "locals" and "remotes" (as they are special cases here)
+ *  - resolves from the duo root for each path
+ *
+ * The "locals" and "remotes" special cases will be tested by the returned
+ * function, and any remaining options will be proxied to babel directly.
+ *
+ * @param {Object} file
+ * @param {Array:String} only
+ * @param {Array:String} ignore
+ * @returns {Boolean}
+ */
+
+function shouldTranspile(only, ignore) {
+  only = normalize(only);
+  ignore = normalize(ignore);
+
+  if (only) {
+    return function (file) {
+      if (only.locals && !file.local()) return false;
+      if (only.remotes && !file.remote()) return false;
+      return true;
+    };
+  } else if (ignore) {
+    return function (file) {
+      if (ignore.locals && file.local()) return false;
+      if (ignore.remotes && file.remote()) return false;
+      return true;
+    };
+  } else {
+    return function () {
+      return true;
+    }
   }
+}
+
+/**
+ * Normalizes a list of patterns.
+ *
+ * @param {Array:String} list
+ * @returns {Object}
+ */
+
+function normalize(list) {
+  if (!list || !list.length) return false;
+
+  return {
+    locals: extract(list, 'locals'),
+    remotes: extract(list, 'remotes'),
+    list: list
+  };
+}
+
+/**
+ * Extracts a set of values from an array.
+ *
+ * @param {Array} input
+ * @param {Mixed} item
+ * @returns {Array}
+ */
+
+function extract(input, item) {
+  var x = input.indexOf(item);
+
+  if (x > -1) {
+    input.splice(x, 1);
+    return true;
+  } else {
+    return false;
+  }
+}
+
+function prepend(list, prefix) {
+  if (!list) return false;
+
+  return list.map(function (item) {
+    return path.resolve(prefix, item);
+  });
 }

--- a/test/components/sum-es5@0.0.0/index.js
+++ b/test/components/sum-es5@0.0.0/index.js
@@ -7,6 +7,6 @@
  * "use strict"; is added to the source code.
  */
 
-function add(a, a, c) {
+module.exports = function sum(a, b, c, d, d) {
   return a + b + c;
-}
+};

--- a/test/components/sum-es6@0.0.0/index.js
+++ b/test/components/sum-es6@0.0.0/index.js
@@ -1,0 +1,4 @@
+
+module.exports = function sum(...args) {
+  return args.reduce((acc, x) => acc + x, 0);
+};

--- a/test/fixtures/es5-local-es5-remote.js
+++ b/test/fixtures/es5-local-es5-remote.js
@@ -1,0 +1,4 @@
+
+var sum = require('sum/es5@0.0.0');
+
+module.exports = sum(1, 2, 3);

--- a/test/fixtures/es5-local-es6-remote.js
+++ b/test/fixtures/es5-local-es6-remote.js
@@ -1,0 +1,8 @@
+
+var sum = require('sum/es6@0.0.0');
+
+module.exports = sum(1, 2, 3);
+
+
+// this will throw an exception in strict mode, which tells us it's been transpiled
+function noop(a, a) {}

--- a/test/fixtures/es6-local-es5-remote.js
+++ b/test/fixtures/es6-local-es5-remote.js
@@ -1,0 +1,4 @@
+
+import sum from 'sum/es5@0.0.0';
+
+module.exports = sum(1, 2, 3);

--- a/test/fixtures/es6-local-es6-remote.js
+++ b/test/fixtures/es6-local-es6-remote.js
@@ -1,0 +1,4 @@
+
+import sum from 'sum/es6@0.0.0';
+
+export default var value = sum(1, 2, 3);

--- a/test/fixtures/remote.js
+++ b/test/fixtures/remote.js
@@ -1,9 +1,0 @@
-
-/**
- * This version of keypath throws an exception in strict mode. (an undeclared
- * variable)
- *
- * @see https://github.com/ripplejs/keypath/blob/0.0.1/index.js#L17
- */
-
-require('fake/remote@0.0.0');

--- a/test/fixtures/specific-remotes.js
+++ b/test/fixtures/specific-remotes.js
@@ -1,0 +1,5 @@
+
+var es5 = require('sum/es5@0.0.0');
+var es6 = require('sum/es6@0.0.0');
+
+module.exports = es5(1, 2, 3) === es6(1, 2, 3);

--- a/test/index.js
+++ b/test/index.js
@@ -24,11 +24,55 @@ describe('duo-babel', function() {
   });
 
   it('should only compile local js files', function(done) {
-    build('remote', { onlyLocals: true }).run(function (err, src) {
+    build('es6-local-es5-remote', { only: [ 'locals' ] }).run(function (err, src) {
       if (err) return done(err);
-      // console.log(src);
       var ret = evaluate(src.code);
-      // console.log(ret);
+      assert.equal(ret, 6);
+      done();
+    });
+  });
+
+  it('should only compile remote js files', function(done) {
+    build('es5-local-es6-remote', { only: [ 'remotes' ] }).run(function (err, src) {
+      if (err) return done(err);
+      var ret = evaluate(src.code);
+      assert.equal(ret, 6);
+      done();
+    });
+  });
+
+  it('should not compile local js files', function(done) {
+    build('es5-local-es6-remote', { ignore: [ 'locals' ] }).run(function (err, src) {
+      if (err) return done(err);
+      var ret = evaluate(src.code);
+      assert.equal(ret, 6);
+      done();
+    });
+  });
+
+  it('should not compile remote js files', function(done) {
+    build('es6-local-es5-remote', { ignore: [ 'remotes' ] }).run(function (err, src) {
+      if (err) return done(err);
+      var ret = evaluate(src.code);
+      assert.equal(ret, 6);
+      done();
+    });
+  });
+
+  it('should only compile the specified remote', function (done) {
+    build('specific-remotes', { only: [ 'components/sum-es6*/**.js' ] }).run(function (err, src) {
+      if (err) return done(err);
+      var ret = evaluate(src.code);
+      assert(ret);
+      done();
+    });
+  });
+
+  it('should only compile the specified remote', function (done) {
+    build('specific-remotes', { ignore: [ 'components/sum-es5*/**.js' ] }).run(function (err, src) {
+      if (err) return done(err);
+      var ret = evaluate(src.code);
+      assert(ret);
       done();
     });
   });


### PR DESCRIPTION
This addresses #8 by adding proper support for the `only` and `ignore` configuration options. In some cases, transpilation can be undesired:
- most of our dependencies don't publish as ES6, so time spent building those is unnecessary
- some dependencies can throw errors because of the addition of `"use strict";` where it was not previously expected
- some dependencies (lodash, react, etc) can be very large, sometimes to the point where babel refuses to transpile them (plus they don't even _need_ to be)

Anyways, the point is the ability to be more deliberate about what should and should not be transpiled is quite useful. (this does away with the `onlyLocals` option, as this syntax is far more flexible)

``` js
var babel = require('duo-babel');

// default behavior, transpile all the things
duo.use(babel());

// only process locals (identical to the old onlyLocals config)
duo.use(babel({
  only: [ 'locals' ]
}));

// whitelist locals and certain remotes
duo.use(babel({
  only: [ 'locals', 'components/segmentio-*/**.js' ]
}));

// blacklist certain locals and remotes
duo.use(babel({
  ignore: [ 'lib/react.js', 'components/lodash*/**.js' ]
}));
```

Notice, we are taking advantage of the directory structure that duo creates, as babel already has a pretty robust system internally. We only added some sugar here for our special cases. (ie: "locals" and "remotes")
