### PR TITLE
Add Cache Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "convert-source-map": "^1.0.0",
-    "duo": "^0.13.0",
+    "duo": "^0.13.2",
     "mocha": "^2.2.4",
     "rimraf": "^2.4.1"
   }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   },
   "devDependencies": {
     "convert-source-map": "^1.0.0",
-    "duo": "^0.11.2",
-    "mocha": "^2.2.4"
+    "duo": "^0.13.0",
+    "mocha": "^2.2.4",
+    "rimraf": "^2.4.1"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -127,19 +127,21 @@ describe('duo-babel', function() {
       });
   });
 
-  describe('with cache enabled', function () {
-    it('should still work', function(done) {
-      build('simple.js').cache(true).run(done);
+  describe.only('with cache enabled', function () {
+    afterEach(function (done) {
+      build('simple.js').cache(true).cleanCache(done);
     });
 
     it('should be significantly faster', function(done) {
+      var duo = build('simple.js').cache(true);
+
       var timer1 = timer();
-      build('simple.js').run(function (err, src) {
+      duo.run(function (err, src) {
         if (err) return done(err);
         var noCache = timer1();
 
         var timer2 = timer();
-        build('simple.js').cache(true).run(function (err, src) {
+        duo.run(function (err, src) {
           if (err) return done(err);
 
           var withCache = timer2();

--- a/test/index.js
+++ b/test/index.js
@@ -127,7 +127,7 @@ describe('duo-babel', function() {
       });
   });
 
-  describe.only('with cache enabled', function () {
+  describe('with cache enabled', function () {
     afterEach(function (done) {
       build('simple.js').cache(true).cleanCache(done);
     });

--- a/test/index.js
+++ b/test/index.js
@@ -4,15 +4,20 @@
  */
 
 var assert = require('assert');
+var babel = require('..');
 var convert = require('convert-source-map');
 var Duo = require('duo');
 var path = require('path');
-var babel = require('..');
+var rm = require('rimraf').sync;
 var vm = require('vm');
 
 /**
  * Tests
  */
+
+after(function () {
+  rm(path.join(__dirname, 'components/duo-cache'));
+});
 
 describe('duo-babel', function() {
   it('should compile .js', function(done) {
@@ -121,6 +126,29 @@ describe('duo-babel', function() {
         done();
       });
   });
+
+  describe('with cache enabled', function () {
+    it('should still work', function(done) {
+      build('simple.js').cache(true).run(done);
+    });
+
+    it('should be significantly faster', function(done) {
+      var timer1 = timer();
+      build('simple.js').run(function (err, src) {
+        if (err) return done(err);
+        var noCache = timer1();
+
+        var timer2 = timer();
+        build('simple.js').cache(true).run(function (err, src) {
+          if (err) return done(err);
+
+          var withCache = timer2();
+          assert(withCache < noCache / 2);
+          done();
+        });
+      });
+    });
+  });
 });
 
 /**
@@ -148,4 +176,19 @@ function build(fixture, options) {
 function evaluate(src, ctx) {
   ctx = ctx || { console: console };
   return vm.runInNewContext(src, ctx)(1);
+}
+
+/**
+ * Create a timer. The function returned should be called
+ * later and it will return the number of ms since it was
+ * created.
+ *
+ * @returns {Function}
+ */
+
+function timer() {
+  var now = (new Date()).getTime();
+  return function () {
+    return (new Date()).getTime() - now;
+  };
 }

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,1 @@
+--harmony-generators

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,0 @@
---harmony-generators


### PR DESCRIPTION
As of `duo@0.13.1`, the underlying cache system has been heavily revised and now exposes caching capability to plugins like this one.

The gist is, based on a hash of both the input source code _and_ the configured options, a unique key is generated that will be used to cache the results of `babel.transform()`. This should speed things up considerably for people with lots of files being transpiled via Duo. (like where I work)

This change to the plugin is **not** backwards-compatible with `duo@<0.13.1`, so I will likely be bumping major on this particular release.
